### PR TITLE
Fixing logo url 404

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -21,7 +21,7 @@ author:
   url: https://18f.gsa.gov
 
 # Point the logo URL at a file in your repo or hosted elsewhere by your organization
-logourl: http://18f.github.io/api-program/assets/img/18f-logo.png
+logourl: https://pages.18f.gov/api-program/assets/img/18f-logo.png
 logoalt: 18f logo
 
 # Navigation


### PR DESCRIPTION
Cool repo! Just fixing a 404 that I saw on the public site.
