### PR TITLE
Add outline of some basic api.data.gov integration instructions

### DIFF
--- a/pages/18f-manual.md
+++ b/pages/18f-manual.md
@@ -9,15 +9,16 @@ permalink: /18f-manual/
 
 ### How to Set Up a New Instance of the API
 
-... 
-
-### How to Get DNS Access From the New Agency
-
-...
+... Deploy to Cloud.gov ...
 
 ### Set up Agency Access for the API and api.data.gov 
 
-... 
+In the api.data.gov admin, complete the following steps:
+
+1. Create a new [API Scope](https://api.data.gov/admin/#/api_scopes) for `api.18f.gov/agency/`
+2. Create a new [Admin Group](https://api.data.gov/admin/#/admin_groups) to give permissions to that API Scope.
+3. Add any agency [Admin Accounts](https://api.data.gov/admin/#/admins) to that Admin Group.
+4. Create and publish a new [API Backend](https://api.data.gov/admin/#/apis) pointing from `api.18f.gov/agency/` to wherever the underlying AutoAPI instance lives.
 
 ### How to Set Up the New Developer Hub
 

--- a/pages/18f-manual.md
+++ b/pages/18f-manual.md
@@ -13,12 +13,12 @@ permalink: /18f-manual/
 
 ### Set up Agency Access for the API and api.data.gov 
 
-In the api.data.gov admin, complete the following steps to deploy the autoapi instance to `api.18f.gov/agency/`:
+In the api.data.gov admin, complete the following steps to deploy the AutoAPI instance to `api.18f.gov/agency/`:
 
 1. Create a new [API Scope](https://api.data.gov/admin/#/api_scopes) for `api.18f.gov/agency/`
 2. Create a new [Admin Group](https://api.data.gov/admin/#/admin_groups) to give permissions to that API Scope.
 3. Add any agency [Admin Accounts](https://api.data.gov/admin/#/admins) to that Admin Group.
-4. Create and publish a new [API Backend](https://api.data.gov/admin/#/apis) pointing from `api.18f.gov/agency/` to wherever the underlying AutoAPI instance lives.
+4. Create and publish a new [API Backend](https://api.data.gov/admin/#/apis) pointing from `api.18f.gov/agency/` to wherever the underlying AutoAPI instance was deployed on Cloud.gov.
 
 ### How to Set Up the New Developer Hub
 

--- a/pages/18f-manual.md
+++ b/pages/18f-manual.md
@@ -13,7 +13,7 @@ permalink: /18f-manual/
 
 ### Set up Agency Access for the API and api.data.gov 
 
-In the api.data.gov admin, complete the following steps:
+In the api.data.gov admin, complete the following steps to deploy the autoapi instance to `api.18f.gov/agency/`:
 
 1. Create a new [API Scope](https://api.data.gov/admin/#/api_scopes) for `api.18f.gov/agency/`
 2. Create a new [Admin Group](https://api.data.gov/admin/#/admin_groups) to give permissions to that API Scope.
@@ -35,7 +35,5 @@ In the api.data.gov admin, complete the following steps:
 
 ## Process for Transitioning the API to the Agency's Ownership
 
-...
-
-
-
+1. After the agency [picks and assigns](/api-program/agency-manual/#how-to-set-up-the-api) their own domain to api.data.gov, repeat the [api.data.gov setup](#set-up-agency-access-for-the-api-and-apidatagov) for their own domain name.
+2. ...


### PR DESCRIPTION
@gbinal: Despite my rambling, I think this is what our discussion boiled down to.

Assuming we just want to document the `api.18f.gov/agency/*` setup instructions for now, I think it mainly comes down to knowing where the underlying autoapi instance lives on cloud.gov, and then setting up the necessary admin permissions and URL routing. As long as we're deploying to paths underneath api.18f.gov, I think any DNS needs would be deferred to whenever the agency wants to use their own domain.

And again, I think various parts of this could eventually be automated (it looks like there's even something that might automate the API Backend setup in [autoapi/umbrella.py](https://github.com/18F/autoapi/blob/master/umbrella.py)), but I think we'll have a better sense of what needs to be automated after running through this process 1-2 times.

Does all this help make sense of things? Anything else I'm forgetting?
